### PR TITLE
feature(140817): Campo vaga_escola_uuid para vaga_escola e ajusta ref…

### DIFF
--- a/escolhas/admin.py
+++ b/escolhas/admin.py
@@ -15,7 +15,7 @@ class EscolhaAdmin(admin.ModelAdmin):
         'situacao',
         'tipo_vaga',
         'e_retardatario',
-        'vaga_escola_uuid',
+        'vaga_escola',
         'uuid',
         'criado_em',
         'atualizado_em',
@@ -32,7 +32,7 @@ class EscolhaAdmin(admin.ModelAdmin):
                 'situacao',
                 'tipo_vaga',
                 'e_retardatario',
-                'vaga_escola_uuid',
+                'vaga_escola',
             )
         }),
         ('Metadados', {

--- a/escolhas/migrations/0015_convert_vaga_escola_uuid_to_fk.py
+++ b/escolhas/migrations/0015_convert_vaga_escola_uuid_to_fk.py
@@ -1,0 +1,68 @@
+# Generated migration to convert vaga_escola_uuid to ForeignKey
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def migrate_uuid_to_fk(apps, schema_editor):
+    """
+    Migra os dados de vaga_escola_uuid para vaga_escola (ForeignKey).
+    """
+    Escolha = apps.get_model('escolhas', 'Escolha')
+    VagasEscolas = apps.get_model('escolhas', 'VagasEscolas')
+    
+    # Iterar sobre todas as escolhas que têm vaga_escola_uuid
+    for escolha in Escolha.objects.filter(vaga_escola_uuid__isnull=False):
+        try:
+            # Buscar a VagasEscolas pelo UUID
+            vaga_escola = VagasEscolas.objects.get(uuid=escolha.vaga_escola_uuid)
+            # Atribuir a ForeignKey
+            escolha.vaga_escola = vaga_escola
+            escolha.save(update_fields=['vaga_escola'])
+        except VagasEscolas.DoesNotExist:
+            # Se não encontrar a vaga, deixa como None (SET_NULL)
+            escolha.vaga_escola = None
+            escolha.save(update_fields=['vaga_escola'])
+
+
+def reverse_migrate(apps, schema_editor):
+    """
+    Reverte a migração: converte ForeignKey de volta para UUID.
+    """
+    Escolha = apps.get_model('escolhas', 'Escolha')
+    
+    # Iterar sobre todas as escolhas que têm vaga_escola
+    for escolha in Escolha.objects.filter(vaga_escola__isnull=False):
+        # Atribuir o UUID da ForeignKey ao campo UUID
+        escolha.vaga_escola_uuid = escolha.vaga_escola.uuid
+        escolha.save(update_fields=['vaga_escola_uuid'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('escolhas', '0014_add_vagas_restantes'),
+    ]
+
+    operations = [
+        # 1. Adicionar novo campo ForeignKey (temporariamente null=True para permitir migração)
+        migrations.AddField(
+            model_name='escolha',
+            name='vaga_escola',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='escolhas',
+                to='escolhas.vagasescolas',
+                verbose_name='Vaga da Escola'
+            ),
+        ),
+        # 2. Migrar os dados de UUID para ForeignKey
+        migrations.RunPython(migrate_uuid_to_fk, reverse_migrate),
+        # 3. Remover o campo antigo UUID
+        migrations.RemoveField(
+            model_name='escolha',
+            name='vaga_escola_uuid',
+        ),
+    ]

--- a/escolhas/models/escolha.py
+++ b/escolhas/models/escolha.py
@@ -39,8 +39,11 @@ class Escolha(BaseModel):
         default=False,
         verbose_name=_('É retardatário'),
     )
-    vaga_escola_uuid = models.UUIDField(
-        verbose_name=_('UUID da Vaga da Escola'),
+    vaga_escola = models.ForeignKey(
+        'VagasEscolas',
+        on_delete=models.SET_NULL,
+        related_name='escolhas',
+        verbose_name=_('Vaga da Escola'),
         null=True,
         blank=True,
     )
@@ -52,7 +55,7 @@ class Escolha(BaseModel):
         ordering = ['-criado_em']
 
     def __str__(self):
-        return f"{self.candidato_uuid} - {self.vaga_escola_uuid}"
+        return f"{self.candidato_uuid} - {self.vaga_escola.uuid if self.vaga_escola else 'N/A'}"
 
 
 auditlog.register(Escolha) 

--- a/escolhas/serializers/escolha.py
+++ b/escolhas/serializers/escolha.py
@@ -1,12 +1,21 @@
 from rest_framework import serializers
 from ..choices import SituacaoChoices
-from ..models import Escolha
+from ..models import Escolha, VagasEscolas
+from .vagas_escolas import VagasEscolasSerializer
 
 
 class EscolhaSerializer(serializers.ModelSerializer):
     """
     Serializer para o modelo Escolha.
     """
+    # Campo customizado para aceitar UUID da vaga_escola e converter para ForeignKey
+    vaga_escola_uuid = serializers.UUIDField(
+        write_only=True,
+        required=False,
+        allow_null=True,
+        help_text='UUID da vaga da escola. Será convertido para ForeignKey internamente.'
+    )
+    
     class Meta:
         model = Escolha
         fields = [
@@ -17,40 +26,67 @@ class EscolhaSerializer(serializers.ModelSerializer):
             'tipo_vaga',
             'e_retardatario',
             'vaga_escola_uuid',
+            'vaga_escola',
             'criado_em',
             'atualizado_em',
         ]
-        read_only_fields = ['uuid', 'criado_em', 'atualizado_em']
+        read_only_fields = ['uuid', 'criado_em', 'atualizado_em', 'vaga_escola']
         extra_kwargs = {
             'candidato_uuid': {'allow_null': False, 'required': True},
             'concurso_uuid': {'allow_null': False, 'required': True},
             'situacao': {'required': True},
             'tipo_vaga': {'allow_null': True, 'required': False},
-            'vaga_escola_uuid': {'allow_null': True, 'required': False},
         }
+    
+    def to_representation(self, instance):
+        """
+        Converte a ForeignKey vaga_escola para UUID na representação.
+        """
+        data = super().to_representation(instance)
+        # Incluir o UUID da vaga_escola na resposta
+        if instance.vaga_escola:
+            data['vaga_escola_uuid'] = str(instance.vaga_escola.uuid)
+        else:
+            data['vaga_escola_uuid'] = None
+        return data
 
     def validate(self, attrs):
         """
-        Validação customizada: tipo_vaga e vaga_escola_uuid são obrigatórios
+        Validação customizada: tipo_vaga e vaga_escola são obrigatórios
         apenas quando a situação for 'escolha'.
         """
         situacao = attrs.get('situacao')
         # Para atualizações parciais, usar valores do instance se não estiverem em attrs
         if self.instance:
             tipo_vaga = attrs.get('tipo_vaga', self.instance.tipo_vaga)
-            vaga_escola_uuid = attrs.get('vaga_escola_uuid', self.instance.vaga_escola_uuid)
+            vaga_escola_uuid = attrs.get('vaga_escola_uuid')
+            vaga_escola = attrs.get('vaga_escola', self.instance.vaga_escola)
             if not situacao:
                 situacao = self.instance.situacao
         else:
             tipo_vaga = attrs.get('tipo_vaga')
             vaga_escola_uuid = attrs.get('vaga_escola_uuid')
+            vaga_escola = attrs.get('vaga_escola')
+        
+        # Converter UUID para ForeignKey se fornecido
+        if vaga_escola_uuid and not vaga_escola:
+            try:
+                vaga_escola = VagasEscolas.objects.get(uuid=vaga_escola_uuid)
+                attrs['vaga_escola'] = vaga_escola
+            except VagasEscolas.DoesNotExist:
+                raise serializers.ValidationError({
+                    'vaga_escola_uuid': f'VagaEscola com UUID {vaga_escola_uuid} não encontrada.'
+                })
+        
+        # Remover vaga_escola_uuid dos attrs para evitar erro
+        attrs.pop('vaga_escola_uuid', None)
 
         if situacao == SituacaoChoices.ESCOLHA:
             if not tipo_vaga:
                 raise serializers.ValidationError({
                     'tipo_vaga': 'Este campo é obrigatório quando a situação é "escolha".'
                 })
-            if not vaga_escola_uuid:
+            if not vaga_escola:
                 raise serializers.ValidationError({
                     'vaga_escola_uuid': 'Este campo é obrigatório quando a situação é "escolha".'
                 })
@@ -73,7 +109,11 @@ class EscolhaSelectSerializer(serializers.ModelSerializer):
 class EscolhaListSerializer(serializers.ModelSerializer):
     """
     Serializer para listagem de escolhas.
+    Inclui dados completos de vaga_escola, escola e DRE.
     """
+    vaga_escola_uuid = serializers.SerializerMethodField()
+    vaga_escola = VagasEscolasSerializer(read_only=True)
+    
     class Meta:
         model = Escolha
         fields = [
@@ -83,9 +123,14 @@ class EscolhaListSerializer(serializers.ModelSerializer):
             'tipo_vaga',
             'e_retardatario',
             'vaga_escola_uuid',
+            'vaga_escola',
             'criado_em',
             'atualizado_em',
         ]
+    
+    def get_vaga_escola_uuid(self, obj):
+        """Retorna o UUID da vaga_escola se existir."""
+        return str(obj.vaga_escola.uuid) if obj.vaga_escola else None
 
 
 class EscolhaReconvocacaoSerializer(serializers.ModelSerializer):

--- a/escolhas/signals.py
+++ b/escolhas/signals.py
@@ -38,7 +38,7 @@ def escolha_post_save(sender, instance, created, **kwargs):
     - PATCH (edição/reconvocacao): cria histórico quando a situação mudou
     
     Atualiza vagas restantes quando:
-    - POST (criação) com situacao='escolha' e vaga_escola_uuid e tipo_vaga presentes
+    - POST (criação) com situacao='escolha' e vaga_escola e tipo_vaga presentes
     """
     situacao_anterior = getattr(instance, '_situacao_anterior', None)
     situacao_atual = instance.situacao
@@ -66,35 +66,30 @@ def escolha_post_save(sender, instance, created, **kwargs):
         
         # Atualiza vagas restantes quando uma escolha é criada
         if (situacao_atual == SituacaoChoices.ESCOLHA and 
-            instance.vaga_escola_uuid and 
+            instance.vaga_escola and 
             instance.tipo_vaga):
             try:
-                vaga_escola = VagasEscolas.objects.get(uuid=instance.vaga_escola_uuid)
+                vaga_escola = instance.vaga_escola
                 
                 # Decrementa o campo correto baseado no tipo de vaga
                 if instance.tipo_vaga == TipoVagaChoices.DEFINITIVA:
-                    VagasEscolas.objects.filter(uuid=instance.vaga_escola_uuid).update(
+                    VagasEscolas.objects.filter(pk=vaga_escola.pk).update(
                         vagas_definitivas_restantes=F('vagas_definitivas_restantes') - 1
                     )
                     logger.info(
                         f"Vaga definitiva decrementada para escolha {instance.uuid}. "
-                        f"VagaEscola: {instance.vaga_escola_uuid}. "
+                        f"VagaEscola: {vaga_escola.uuid}. "
                         f"Novo valor: {vaga_escola.vagas_definitivas_restantes - 1}"
                     )
                 elif instance.tipo_vaga == TipoVagaChoices.PRECARIA:
-                    VagasEscolas.objects.filter(uuid=instance.vaga_escola_uuid).update(
+                    VagasEscolas.objects.filter(pk=vaga_escola.pk).update(
                         vagas_precarias_restantes=F('vagas_precarias_restantes') - 1
                     )
                     logger.info(
                         f"Vaga precária decrementada para escolha {instance.uuid}. "
-                        f"VagaEscola: {instance.vaga_escola_uuid}. "
+                        f"VagaEscola: {vaga_escola.uuid}. "
                         f"Novo valor: {vaga_escola.vagas_precarias_restantes - 1}"
                     )
-            except VagasEscolas.DoesNotExist:
-                logger.warning(
-                    f"VagaEscola com UUID {instance.vaga_escola_uuid} não encontrada "
-                    f"para escolha {instance.uuid}. Não foi possível atualizar vagas restantes."
-                )
             except Exception as exc:
                 logger.error(
                     f"Erro ao atualizar vagas restantes para escolha {instance.uuid}: {exc}",

--- a/escolhas/tests/conftest.py
+++ b/escolhas/tests/conftest.py
@@ -1,18 +1,118 @@
 import pytest
 from rest_framework.test import APIClient
 from escolhas.choices import SituacaoChoices, TipoVagaChoices
-from escolhas.models import Escolha
+from escolhas.models import Escolha, VagasEscolas, VagasEscolasLote, Escola, Dre
 import uuid
 
 
+@pytest.fixture
+def dre():
+    """Fixture para criar uma DRE."""
+    return Dre.objects.create(codigo="01", nome="DRE 01", sigla="DRE-01")
+
+
+@pytest.fixture
+def escola(dre):
+    """Fixture para criar uma escola."""
+    return Escola.objects.create(
+        codigo_eol="000001",
+        nome_oficial="Escola Teste",
+        dre=dre,
+        cep="04001-000"
+    )
+
+
+@pytest.fixture
+def lote():
+    """Fixture para criar um lote de vagas."""
+    return VagasEscolasLote.objects.create(
+        processo_uuid=uuid.uuid4(),
+        processo_nome="Processo Teste"
+    )
+
+
+@pytest.fixture
+def vaga_escola(escola, lote):
+    """Fixture para criar uma vaga de escola."""
+    return VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=100,
+        cargo_descricao="Cargo Teste",
+        vagas_precarias=3,
+        vagas_precarias_restantes=3,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+
+
 def _criar_escolha(**override):
+    # Se vaga_escola_uuid foi passado, remover e criar uma vaga_escola padrão
+    if 'vaga_escola_uuid' in override:
+        vaga_uuid = override.pop('vaga_escola_uuid')
+        if vaga_uuid:
+            try:
+                override['vaga_escola'] = VagasEscolas.objects.get(uuid=vaga_uuid)
+            except VagasEscolas.DoesNotExist:
+                # Se não encontrar, criar uma vaga padrão
+                dre = Dre.objects.create(codigo="99", nome="DRE Teste", sigla="DRE-TESTE")
+                escola = Escola.objects.create(
+                    codigo_eol="999999",
+                    nome_oficial="Escola Teste",
+                    dre=dre,
+                    cep="00000-000"
+                )
+                lote = VagasEscolasLote.objects.create(
+                    processo_uuid=uuid.uuid4(),
+                    processo_nome="Processo Teste"
+                )
+                override['vaga_escola'] = VagasEscolas.objects.create(
+                    escola=escola,
+                    lote=lote,
+                    data_fechamento_modulo="2025-01-01",
+                    cargo_codigo=100,
+                    cargo_descricao="Cargo Teste",
+                    vagas_precarias=3,
+                    vagas_precarias_restantes=3,
+                    vagas_definitivas=5,
+                    vagas_definitivas_restantes=5,
+                    status="1"
+                )
+    
+    # Se vaga_escola não foi passado, criar uma padrão
+    if 'vaga_escola' not in override:
+        dre = Dre.objects.create(codigo="99", nome="DRE Teste", sigla="DRE-TESTE")
+        escola = Escola.objects.create(
+            codigo_eol="999999",
+            nome_oficial="Escola Teste",
+            dre=dre,
+            cep="00000-000"
+        )
+        lote = VagasEscolasLote.objects.create(
+            processo_uuid=uuid.uuid4(),
+            processo_nome="Processo Teste"
+        )
+        override['vaga_escola'] = VagasEscolas.objects.create(
+            escola=escola,
+            lote=lote,
+            data_fechamento_modulo="2025-01-01",
+            cargo_codigo=100,
+            cargo_descricao="Cargo Teste",
+            vagas_precarias=3,
+            vagas_precarias_restantes=3,
+            vagas_definitivas=5,
+            vagas_definitivas_restantes=5,
+            status="1"
+        )
+    
     dados = {
         'candidato_uuid': uuid.uuid4(),
         'concurso_uuid': uuid.uuid4(),
         'situacao': SituacaoChoices.ESCOLHA,
         'tipo_vaga': TipoVagaChoices.DEFINITIVA,
         'e_retardatario': False,
-        'vaga_escola_uuid': uuid.uuid4(),
     }
     dados.update(override)
     return Escolha.objects.create(**dados)

--- a/escolhas/tests/test_signals.py
+++ b/escolhas/tests/test_signals.py
@@ -60,7 +60,7 @@ def test_signal_decrementa_vaga_definitiva_ao_criar_escolha(vaga_escola_com_vaga
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=vaga_escola_com_vagas.uuid,
+        vaga_escola=vaga_escola_com_vagas,
     )
 
     vaga_escola_com_vagas.refresh_from_db()
@@ -92,7 +92,7 @@ def test_signal_decrementa_vaga_precaria_ao_criar_escolha(escola, lote):
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.PRECARIA,
         e_retardatario=False,
-        vaga_escola_uuid=vaga_escola.uuid,
+        vaga_escola=vaga_escola,
     )
 
     vaga_escola.refresh_from_db()
@@ -124,7 +124,7 @@ def test_signal_nao_decrementa_se_situacao_nao_for_escolha(escola, lote):
         situacao=SituacaoChoices.NAO_ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=vaga_escola.uuid,
+        vaga_escola=vaga_escola,
     )
 
     vaga_escola.refresh_from_db()
@@ -132,8 +132,8 @@ def test_signal_nao_decrementa_se_situacao_nao_for_escolha(escola, lote):
     assert vaga_escola.vagas_precarias_restantes == vagas_precarias_inicial
 
 @pytest.mark.django_db
-def test_signal_nao_decrementa_se_vaga_escola_uuid_nao_fornecido(vaga_escola_com_vagas):
-    """Testa que o signal não decrementa se vaga_escola_uuid não for fornecido."""
+def test_signal_nao_decrementa_se_vaga_escola_nao_fornecido(vaga_escola_com_vagas):
+    """Testa que o signal não decrementa se vaga_escola não for fornecido."""
     vagas_definitivas_inicial = vaga_escola_com_vagas.vagas_definitivas_restantes
     vagas_precarias_inicial = vaga_escola_com_vagas.vagas_precarias_restantes
 
@@ -143,7 +143,7 @@ def test_signal_nao_decrementa_se_vaga_escola_uuid_nao_fornecido(vaga_escola_com
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=None,
+        vaga_escola=None,
     )
 
     vaga_escola_com_vagas.refresh_from_db()
@@ -162,7 +162,7 @@ def test_signal_nao_decrementa_se_tipo_vaga_nao_fornecido(vaga_escola_com_vagas)
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=None,
         e_retardatario=False,
-        vaga_escola_uuid=vaga_escola_com_vagas.uuid,
+        vaga_escola=vaga_escola_com_vagas,
     )
 
     vaga_escola_com_vagas.refresh_from_db()
@@ -172,13 +172,14 @@ def test_signal_nao_decrementa_se_tipo_vaga_nao_fornecido(vaga_escola_com_vagas)
 @pytest.mark.django_db
 def test_signal_nao_falha_se_vaga_escola_nao_existir():
     """Testa que o signal não falha se a vaga_escola não existir."""
+    # Cria uma escolha sem vaga_escola (None)
     escolha = Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         concurso_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=None,
     )
 
     assert Escolha.objects.filter(uuid=escolha.uuid).exists()
@@ -208,7 +209,7 @@ def test_signal_decrementa_multiplas_escolhas_sequencialmente(escola, lote):
             situacao=SituacaoChoices.ESCOLHA,
             tipo_vaga=TipoVagaChoices.DEFINITIVA,
             e_retardatario=False,
-            vaga_escola_uuid=vaga_escola.uuid,
+            vaga_escola=vaga_escola,
         )
 
     vaga_escola.refresh_from_db()
@@ -239,7 +240,7 @@ def test_signal_nao_decrementa_em_atualizacao_apenas_em_criacao(escola, lote):
         situacao=SituacaoChoices.NAO_ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=vaga_escola.uuid,
+        vaga_escola=vaga_escola,
     )
 
     vaga_escola.refresh_from_db()

--- a/escolhas/tests/views/test_escolha.py
+++ b/escolhas/tests/views/test_escolha.py
@@ -29,19 +29,53 @@ def test_list_escolhas_com_dados(api_client, escolha_matematica, escolha_portugu
 
 @pytest.mark.django_db
 def test_filter_candidato_uuid(api_client):
+    # Criar DRE, Escola e VagaEscola para os testes
+    dre = Dre.objects.create(codigo="01", nome="DRE 01", sigla="DRE-01")
+    escola = Escola.objects.create(
+        codigo_eol="000001",
+        nome_oficial="Escola Teste",
+        dre=dre,
+        cep="04001-000"
+    )
+    lote = VagasEscolasLote.objects.create(processo_uuid=uuid.uuid4(), processo_nome="Proc")
+    vaga_escola_1 = VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=100,
+        cargo_descricao="Cargo Teste",
+        vagas_precarias=2,
+        vagas_precarias_restantes=2,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+    vaga_escola_2 = VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=101,
+        cargo_descricao="Cargo Teste 2",
+        vagas_precarias=2,
+        vagas_precarias_restantes=2,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+    
     selecionada = Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=vaga_escola_1,
     )
     Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.NAO_ESCOLHA,
         tipo_vaga=TipoVagaChoices.PRECARIA,
         e_retardatario=False,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=vaga_escola_2,
     )
 
     url = reverse('escolha-list')
@@ -104,26 +138,72 @@ def test_delete_escolha(api_client, escolha_matematica):
 
 @pytest.mark.django_db
 def test_busca_por_candidatos(api_client):
+    # Criar DRE, Escola e VagaEscola para os testes
+    dre = Dre.objects.create(codigo="01", nome="DRE 01", sigla="DRE-01")
+    escola = Escola.objects.create(
+        codigo_eol="000001",
+        nome_oficial="Escola Teste",
+        dre=dre,
+        cep="04001-000"
+    )
+    lote = VagasEscolasLote.objects.create(processo_uuid=uuid.uuid4(), processo_nome="Proc")
+    vaga_escola_1 = VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=100,
+        cargo_descricao="Cargo Teste",
+        vagas_precarias=2,
+        vagas_precarias_restantes=2,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+    vaga_escola_2 = VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=101,
+        cargo_descricao="Cargo Teste 2",
+        vagas_precarias=2,
+        vagas_precarias_restantes=2,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+    vaga_escola_3 = VagasEscolas.objects.create(
+        escola=escola,
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=102,
+        cargo_descricao="Cargo Teste 3",
+        vagas_precarias=2,
+        vagas_precarias_restantes=2,
+        vagas_definitivas=5,
+        vagas_definitivas_restantes=5,
+        status="1"
+    )
+    
     escolha_1 = Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=vaga_escola_1,
     )
     escolha_2 = Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.RECONVOCACAO,
         tipo_vaga=TipoVagaChoices.PRECARIA,
         e_retardatario=True,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=vaga_escola_2,
     )
     Escolha.objects.create(
         candidato_uuid=uuid.uuid4(),
         situacao=SituacaoChoices.NAO_ESCOLHA,
         tipo_vaga=TipoVagaChoices.DEFINITIVA,
         e_retardatario=False,
-        vaga_escola_uuid=uuid.uuid4(),
+        vaga_escola=vaga_escola_3,
     )
 
     url = reverse('escolha-busca')

--- a/escolhas/views/escolha.py
+++ b/escolhas/views/escolha.py
@@ -48,7 +48,11 @@ class EscolhaViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        queryset = self.get_queryset().filter(candidato_uuid__in=candidato_ids)
+        queryset = self.get_queryset().select_related(
+            'vaga_escola',
+            'vaga_escola__escola',
+            'vaga_escola__escola__dre'
+        ).filter(candidato_uuid__in=candidato_ids)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
Renomeia campo vaga_escola_uuid para vaga_escola e ajusta referências no código

- Atualiza o modelo Escolha para usar uma ForeignKey em vez de um UUID para vaga_escola.
- Modifica o serializer EscolhaSerializer para incluir a nova lógica de conversão de UUID para ForeignKey.
- Ajusta os testes para refletir a mudança de campo e garantir a integridade das funcionalidades relacionadas.
- Melhora a performance das consultas ao usar select_related nas views

[AB#133390](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/133390) [AB#140917](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/140917)