### PR TITLE
feat(147137): integrar sigla-sdk, JWT e ampliar auditoria

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -33,7 +33,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'escolhas.middleware.CorrelationIdMiddleware',
+    'sigla_sdk.middlewares.CorrelationIdMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -42,7 +42,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'auditlog.middleware.AuditlogMiddleware',
+    'sigla_sdk.middlewares.AuditlogJWTMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -142,6 +142,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.AllowAny',  # Para facilitar testes
@@ -150,18 +151,14 @@ REST_FRAMEWORK = {
 }
 
 # AuditLog settings
-AUDITLOG_INCLUDE_ALL_MODELS = False 
-
-import threading
-_thread_locals = threading.local()
+AUDITLOG_INCLUDE_ALL_MODELS = False
 
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
         'json': {
-            '()': 'escolhas.logging_utils.CustomJsonFormatter', # Usa sua classe
-            # Estes campos do logging padrão virarão chaves no JSON
+            '()': 'sigla_sdk.logging.json_formatter.CustomJsonFormatter',
             'format': '%(levelname)s %(asctime)s %(module)s %(filename)s %(lineno)d %(funcName)s %(message)s'
         },
     },
@@ -173,13 +170,11 @@ LOGGING = {
         },
     },
     'loggers': {
-        # Logger do Django (Framework)
         'django': {
             'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,
         },
-        # Seu Logger de Aplicação (substitua pelo nome do seu app)
         'escolhas': {
             'handlers': ['console'],
             'level': 'DEBUG',
@@ -187,7 +182,7 @@ LOGGING = {
         },
         'django.server': {
             'handlers': ['console'],
-            'level': 'ERROR',  # Alterando para ERROR, ele para de mostrar os GET/POST/OPTIONS de rotina (INFO)
+            'level': 'ERROR',
             'propagate': False,
         },
     },
@@ -210,3 +205,15 @@ PROCESSOS_CONVOCACAO_API_URL = os.environ.get('PROCESSOS_CONVOCACAO_API_URL', 'h
 PROCESSOS_CONVOCACAO_API_TIMEOUT = int(os.environ.get('PROCESSOS_CONVOCACAO_API_TIMEOUT', 30))
 
 CONCURSOS_API_URL = os.environ.get('CONCURSOS_API_URL', 'http://localhost:8001')
+
+from datetime import timedelta
+
+JWT_SIGNING_KEY = os.environ.get('JWT_SIGNING_KEY', os.environ.get('SECRET_KEY', 'fallback-só-dev'))
+
+SIMPLE_JWT = {
+    'SIGNING_KEY': JWT_SIGNING_KEY,
+    'ALGORITHM': 'HS256',
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=1440),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
+    'AUTH_HEADER_TYPES': ('Bearer',),
+}

--- a/escolhas/models/historico_escolha.py
+++ b/escolhas/models/historico_escolha.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from auditlog.registry import auditlog
 from ..choices import SituacaoChoices
 from .base import BaseModel
 
@@ -36,4 +37,7 @@ class HistoricoEscolha(BaseModel):
 
     def __str__(self):
         return f"{self.escolha.uuid} - {self.situacao_anterior} -> {self.situacao_nova}"
+
+
+auditlog.register(HistoricoEscolha)
 

--- a/escolhas/models/vagas_lote.py
+++ b/escolhas/models/vagas_lote.py
@@ -1,4 +1,5 @@
 from django.db import models
+from auditlog.registry import auditlog
 from .base import BaseModel
 
 
@@ -13,4 +14,7 @@ class VagasEscolasLote(BaseModel):
         ordering = ['-criado_em']
 
     def __str__(self):
-        return f"{self.processo_nome} ({self.processo_uuid})" 
+        return f"{self.processo_nome} ({self.processo_uuid})"
+
+
+auditlog.register(VagasEscolasLote)

--- a/escolhas/services/candidato_api.py
+++ b/escolhas/services/candidato_api.py
@@ -1,9 +1,8 @@
-from typing import Optional
+from typing import Optional, List
 import logging
-import requests
 from django.conf import settings
-from typing import List
-from escolhas.middleware import get_correlation_id
+from sigla_sdk.context import get_correlation_id
+from sigla_sdk.http.api_client import http_client
 
 
 logger = logging.getLogger(__name__)
@@ -57,14 +56,14 @@ class CandidatoAPIService:
             }
         )
         try:
-            response = requests.post(
+            response = http_client.post(
                 url,
                 json=payload,
                 headers=self._default_headers,
                 timeout=self.timeout_seconds
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as exc:
+        except Exception as exc:
             logger.error(f'Erro HTTP ao buscar candidatos por CPFs {cpfs} no processo {processo_uuid}: {exc}')
             return None
         except Exception as exc:
@@ -131,16 +130,13 @@ class CandidatoAPIService:
             params['registro_funcional'] = str(registro_funcional).strip()
 
         try:
-            response = requests.get(
+            response = http_client.get(
                 url,
                 params=params,
                 headers=self._default_headers,
                 timeout=self.timeout_seconds,
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as exc:
-            logger.error('Erro HTTP ao buscar candidatos: %s', exc)
-            return None
         except Exception as exc:
             logger.error('Erro ao buscar candidatos: %s', exc, exc_info=True)
             return None

--- a/escolhas/services/concurso_api.py
+++ b/escolhas/services/concurso_api.py
@@ -1,8 +1,8 @@
 from typing import Optional, List, Dict, Any
 import logging
-import requests
 from django.conf import settings
-from escolhas.middleware import get_correlation_id
+from sigla_sdk.context import get_correlation_id
+from sigla_sdk.http.api_client import http_client
 
 
 logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class ConcursoAPIService:
         try:
             # Busca por código (filtro no MS-Concursos) para não depender de paginação
             for cod in codigos_set:
-                response = requests.get(url, params={"codigo": cod}, timeout=30)
+                response = http_client.get(url, params={"codigo": cod}, timeout=30)
                 response.raise_for_status()
                 data = response.json()
                 lista = _cargos_list_from_response(data)
@@ -61,11 +61,8 @@ class ConcursoAPIService:
                         result[cod] = item.get("nome") or ""
                         break
             return result
-        except requests.exceptions.RequestException as exc:
-            logger.warning("Erro ao buscar cargos no MS-Concursos: %s", exc)
-            return {}
         except Exception as exc:
-            logger.warning("Erro ao processar resposta de cargos: %s", exc, exc_info=True)
+            logger.warning("Erro ao buscar cargos no MS-Concursos: %s", exc, exc_info=True)
             return {}
 
     @staticmethod
@@ -82,13 +79,10 @@ class ConcursoAPIService:
         try:
             base_url = settings.CONCURSOS_API_URL
             url = f"{base_url}/api/v1/concursos/{concurso_uuid}/"
-            response = requests.get(url, timeout=30)
+            response = http_client.get(url, timeout=30)
             response.raise_for_status()
             return response.json().get('uuid')
-        
-        except requests.exceptions.RequestException as exc:
-            logger.error(f'Erro HTTP ao buscar concurso_uuid para concurso {concurso_uuid}: {exc}')
-            return None
+
         except Exception as exc:
             logger.error(f'Erro ao buscar concurso_uuid para concurso {concurso_uuid}: {exc}', exc_info=True)
             return None

--- a/escolhas/tests/services/test_candidato_api.py
+++ b/escolhas/tests/services/test_candidato_api.py
@@ -4,7 +4,6 @@ Testes unitários para CandidatoAPIService.
 import pytest
 from unittest.mock import patch, Mock
 import requests
-from django.conf import settings
 
 from escolhas.services.candidato_api import CandidatoAPIService
 
@@ -34,10 +33,10 @@ class TestCandidatoAPIService:
         """Testa busca de candidatos por CPFs com sucesso."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901', '98765432100']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
+
         mock_response_data = [
             {
                 'uuid': 'candidato-uuid-1',
@@ -50,15 +49,15 @@ class TestCandidatoAPIService:
                 'nome': 'Candidato 2'
             }
         ]
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
             mock_post.return_value = mock_response
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result == mock_response_data
             mock_post.assert_called_once()
             call_args = mock_post.call_args
@@ -74,98 +73,98 @@ class TestCandidatoAPIService:
         """Testa busca com lista de CPFs vazia."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = []
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
+
         mock_response_data = []
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
             mock_post.return_value = mock_response
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result == mock_response_data
 
     def test_buscar_candidatos_por_cpfs_http_error(self, settings):
         """Testa tratamento de erro HTTP."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_post.side_effect = requests.exceptions.HTTPError('404 Not Found')
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result is None
 
     def test_buscar_candidatos_por_cpfs_connection_error(self, settings):
         """Testa tratamento de erro de conexão."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_post.side_effect = requests.exceptions.ConnectionError('Connection failed')
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result is None
 
     def test_buscar_candidatos_por_cpfs_timeout(self, settings):
         """Testa tratamento de timeout."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_post.side_effect = requests.exceptions.Timeout('Request timeout')
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result is None
 
     def test_buscar_candidatos_por_cpfs_excecao_generica(self, settings):
         """Testa tratamento de exceção genérica."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_post.side_effect = Exception('Erro genérico')
-            
+
             result = service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             assert result is None
 
     def test_buscar_candidatos_por_cpfs_timeout_personalizado(self, settings):
         """Testa que usa timeout personalizado."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService(timeout_seconds=60)
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_response = Mock()
             mock_response.json.return_value = []
             mock_response.raise_for_status.return_value = None
             mock_post.return_value = mock_response
-            
+
             service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             call_args = mock_post.call_args
             assert call_args[1]['timeout'] == 60
 
@@ -173,24 +172,24 @@ class TestCandidatoAPIService:
         """Testa que headers estão corretos."""
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
-        
+
         cpfs = ['12345678901']
         processo_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.candidato_api.requests.post') as mock_post:
+
+        with patch('sigla_sdk.http.api_client.http_client.post') as mock_post:
             mock_response = Mock()
             mock_response.json.return_value = []
             mock_response.raise_for_status.return_value = None
             mock_post.return_value = mock_response
-            
+
             service.buscar_candidatos_por_cpfs(cpfs, processo_uuid)
-            
+
             call_args = mock_post.call_args
             headers = call_args[1]['headers']
             assert headers['Accept'] == 'application/json'
             assert headers['Content-Type'] == 'application/json'
 
-    # --- Testes de buscar_candidatos (feature/143715-consulta-concursado) ---
+    # --- Testes de buscar_candidatos ---
 
     def test_buscar_candidatos_sucesso(self, settings):
         """Testa busca de candidatos por nome/cpf/rg/registro_funcional com sucesso."""
@@ -201,7 +200,7 @@ class TestCandidatoAPIService:
             {'nome': 'João', 'cpf': '12345678901', 'concursos': []},
         ]
 
-        with patch('escolhas.services.candidato_api.requests.get') as mock_get:
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
@@ -221,7 +220,7 @@ class TestCandidatoAPIService:
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
 
-        with patch('escolhas.services.candidato_api.requests.get') as mock_get:
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             result = service.buscar_candidatos()
 
             assert result == []
@@ -232,7 +231,7 @@ class TestCandidatoAPIService:
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
 
-        with patch('escolhas.services.candidato_api.requests.get') as mock_get:
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_response = Mock()
             mock_response.json.return_value = []
             mock_response.raise_for_status.return_value = None
@@ -258,7 +257,7 @@ class TestCandidatoAPIService:
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
 
-        with patch('escolhas.services.candidato_api.requests.get') as mock_get:
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.HTTPError('502 Bad Gateway')
 
             result = service.buscar_candidatos(nome='Teste')
@@ -270,10 +269,9 @@ class TestCandidatoAPIService:
         settings.CANDIDATOS_API_URL = 'http://test-api.com'
         service = CandidatoAPIService()
 
-        with patch('escolhas.services.candidato_api.requests.get') as mock_get:
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.ConnectionError()
 
             result = service.buscar_candidatos(cpf='123')
 
             assert result is None
-

--- a/escolhas/tests/services/test_concurso_api.py
+++ b/escolhas/tests/services/test_concurso_api.py
@@ -15,20 +15,20 @@ class TestConcursoAPIService:
         """Testa busca de concurso_uuid com sucesso."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
+
         mock_response_data = {
             'uuid': concurso_uuid,
             'nome': 'Concurso Teste'
         }
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result == concurso_uuid
             mock_get.assert_called_once()
             call_args = mock_get.call_args
@@ -39,99 +39,99 @@ class TestConcursoAPIService:
         """Testa quando concurso não é encontrado."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
+
         mock_response_data = {
             'uuid': None,
             'nome': 'Concurso Teste'
         }
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_http_error_404(self, settings):
         """Testa tratamento de erro HTTP 404."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.HTTPError('404 Not Found')
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_http_error_500(self, settings):
         """Testa tratamento de erro HTTP 500."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.HTTPError('500 Internal Server Error')
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_connection_error(self, settings):
         """Testa tratamento de erro de conexão."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.ConnectionError('Connection failed')
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_timeout(self, settings):
         """Testa tratamento de timeout."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = requests.exceptions.Timeout('Request timeout')
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_excecao_generica(self, settings):
         """Testa tratamento de exceção genérica."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_get.side_effect = Exception('Erro genérico')
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_resposta_sem_uuid(self, settings):
         """Testa quando resposta não contém campo uuid."""
         settings.CONCURSOS_API_URL = 'http://test-api.com'
         concurso_uuid = '123e4567-e89b-12d3-a456-426614174000'
-        
+
         mock_response_data = {
             'nome': 'Concurso Teste'
         }
-        
-        with patch('escolhas.services.concurso_api.requests.get') as mock_get:
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
             mock_response = Mock()
             mock_response.json.return_value = mock_response_data
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
-            
+
             result = ConcursoAPIService.buscar_concurso_uuid(concurso_uuid)
-            
+
             assert result is None
 
     def test_buscar_concurso_uuid_metodo_estatico(self):
@@ -140,3 +140,47 @@ class TestConcursoAPIService:
         assert inspect.ismethod(ConcursoAPIService.buscar_concurso_uuid) is False
         assert hasattr(ConcursoAPIService, 'buscar_concurso_uuid')
 
+    def test_get_cargos_por_codigos_sucesso(self, settings):
+        """Testa busca de cargos por códigos com sucesso."""
+        settings.CONCURSOS_API_URL = 'http://test-api.com'
+
+        mock_response_data = [{'codigo': '10', 'nome': 'Professor'}]
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
+            mock_response = Mock()
+            mock_response.json.return_value = mock_response_data
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            result = ConcursoAPIService.get_cargos_por_codigos(['10'])
+
+            assert result == {'10': 'Professor'}
+
+    def test_get_cargos_por_codigos_lista_vazia(self, settings):
+        """Testa que lista vazia retorna dict vazio sem chamar API."""
+        settings.CONCURSOS_API_URL = 'http://test-api.com'
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
+            result = ConcursoAPIService.get_cargos_por_codigos([])
+            assert result == {}
+            mock_get.assert_not_called()
+
+    def test_get_cargos_por_codigos_sem_url(self, settings):
+        """Testa que sem CONCURSOS_API_URL retorna dict vazio."""
+        settings.CONCURSOS_API_URL = ''
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
+            result = ConcursoAPIService.get_cargos_por_codigos(['10'])
+            assert result == {}
+            mock_get.assert_not_called()
+
+    def test_get_cargos_por_codigos_erro_http(self, settings):
+        """Testa que erro HTTP retorna dict vazio."""
+        settings.CONCURSOS_API_URL = 'http://test-api.com'
+
+        with patch('sigla_sdk.http.api_client.http_client.get') as mock_get:
+            mock_get.side_effect = requests.exceptions.ConnectionError('err')
+
+            result = ConcursoAPIService.get_cargos_por_codigos(['10'])
+
+            assert result == {}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,5 @@ django-auditlog==3.2.1
 python-dotenv==1.1.1
 drf-spectacular==0.28.0
 python-json-logger==4.0.0
+djangorestframework_simplejwt==5.5.1
+git+https://github.com/prefeiturasp/SME-SIGLA-SDK-Microsservico.git@1.0.1#egg=sigla-sdk


### PR DESCRIPTION
Este PR padroniza o serviço de Escolhas - fortalecendo rastreabilidade e autenticação entre microsserviços.

O que foi alterado

1. middlewares atualizados para usar correlation id e auditlog JWT do sigla-sdk
2. configuração de autenticação JWT adicionada ao DRF
3. configuração SimpleJWT adicionada (chave, algoritmo, tempo de vida de tokens e header Bearer)
4. logging migrado para formatter JSON do sigla-sdk
5. serviços de integração com Candidatos e Concursos migrados de requests para http_client do sigla-sdk
6. modelos HistoricoEscolha e VagasEscolasLote registrados no auditlog
7. testes unitários atualizados para novos pontos de patch e novos cenários em ConcursoAPIService
8. requirements atualizados com simplejwt e sigla-sdk

[AB#147146](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147146)
[AB#147137](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147137)
[AB#147000](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/147000)