### PR TITLE
feat(150057): endpoint de extração de dados de escolhas (por situação DRE)

### DIFF
--- a/escolhas/serializers/__init__.py
+++ b/escolhas/serializers/__init__.py
@@ -14,6 +14,7 @@ from .escolhas_prodam import (
     EscolhaProdamItemSerializer,
     EscolhasProdamImportacaoSerializer,
 )
+from .extracao_dados import ExtracaoDadosSerializer
 from .parametrizacao import (
     ParametrizacaoBulkItemSerializer,
     ParametrizacaoSerializer,

--- a/escolhas/serializers/extracao_dados.py
+++ b/escolhas/serializers/extracao_dados.py
@@ -19,10 +19,14 @@ class ExtracaoDadosFiltroSerializer(serializers.Serializer):
 class ExtracaoDadosSerializer(serializers.Serializer):
     """Payload do endpoint de extração de dados de escolhas.
 
-    - ``concurso_uuid``: concurso cujas escolhas serão contadas.
-    - ``filtros``: lista de ``{ano}``; cada ano filtra as escolhas pelo
-      ano de criação (``criado_em``).
+    - ``concurso_uuid`` (opcional): concurso cujas escolhas serão contadas.
+      Ausente → agrega escolhas de todos os concursos.
+    - ``filtros`` (opcional): lista de ``{ano}``; cada ano filtra as escolhas
+      pelo ano de criação (``criado_em``). Ausente (ou vazia) → o resultado traz
+      uma única chave agregada ``"total"`` sem quebra por ano.
     """
 
-    concurso_uuid = serializers.UUIDField()
-    filtros = ExtracaoDadosFiltroSerializer(many=True, allow_empty=False)
+    concurso_uuid = serializers.UUIDField(required=False, allow_null=True)
+    filtros = ExtracaoDadosFiltroSerializer(
+        many=True, required=False, default=list
+    )

--- a/escolhas/serializers/extracao_dados.py
+++ b/escolhas/serializers/extracao_dados.py
@@ -1,0 +1,28 @@
+from rest_framework import serializers
+
+
+class ExtracaoDadosFiltroSerializer(serializers.Serializer):
+    """Filtro de um ano.
+
+    ``processo_uuids`` (opcional) é usado apenas para somar as vagas por DRE,
+    pois ``VagasEscolas`` só se liga ao processo via ``lote.processo_uuid``.
+    """
+
+    ano = serializers.IntegerField()
+    processo_uuids = serializers.ListField(
+        child=serializers.UUIDField(),
+        required=False,
+        allow_empty=True,
+    )
+
+
+class ExtracaoDadosSerializer(serializers.Serializer):
+    """Payload do endpoint de extração de dados de escolhas.
+
+    - ``concurso_uuid``: concurso cujas escolhas serão contadas.
+    - ``filtros``: lista de ``{ano}``; cada ano filtra as escolhas pelo
+      ano de criação (``criado_em``).
+    """
+
+    concurso_uuid = serializers.UUIDField()
+    filtros = ExtracaoDadosFiltroSerializer(many=True, allow_empty=False)

--- a/escolhas/services/__init__.py
+++ b/escolhas/services/__init__.py
@@ -1,5 +1,6 @@
 from .candidato_api import CandidatoAPIService
 from .concurso_api import ConcursoAPIService
+from .extracao_dados import montar_extracao_dados
 from .sme_integration import (
     buscar_dados_escola_por_eol,
     buscar_dres_de_smeintegracao,

--- a/escolhas/services/extracao_dados.py
+++ b/escolhas/services/extracao_dados.py
@@ -1,0 +1,96 @@
+"""Agregações para a extração de dados de escolhas."""
+
+from django.db.models import Count, F, Sum
+
+from escolhas.choices import SituacaoChoices
+from escolhas.models import Escolha, VagasEscolas
+
+
+def montar_extracao_dados(concurso_uuid, filtros) -> dict:
+    """
+    Monta o dicionário de indicadores de escolhas por ano.
+
+    Para cada ``ano`` (de ``filtros``), conta as escolhas do ``concurso_uuid``
+    por ``situacao`` (escolha / reconvocacao / nao-escolha), filtrando pelo
+    ano de criação (``criado_em``), e monta o array ``dres`` com escolhas e
+    vagas por DRE.
+
+    Filtramos por ``Escolha.concurso_uuid`` (sempre preenchido) e NÃO pela
+    vaga, porque escolhas ``nao-escolha`` / ``reconvocacao`` normalmente não
+    têm ``vaga_escola`` vinculada — filtrar pela vaga as excluiria.
+    """
+    resultado = {}
+    for filtro in filtros:
+        ano = filtro["ano"]
+        processo_uuids = filtro.get("processo_uuids") or []
+        dados = _contar_situacoes(concurso_uuid, ano)
+        dados["dres"] = _montar_dres(concurso_uuid, ano, processo_uuids)
+        resultado[str(ano)] = dados
+    return resultado
+
+
+def _contar_situacoes(concurso_uuid, ano) -> dict:
+    contagens = (
+        Escolha.objects.filter(
+            concurso_uuid=concurso_uuid, criado_em__year=ano
+        )
+        .values("situacao")
+        .annotate(total=Count("uuid"))
+    )
+    por_situacao = {item["situacao"]: item["total"] for item in contagens}
+    return {
+        "escolha": por_situacao.get(SituacaoChoices.ESCOLHA, 0),
+        "reconvocacao": por_situacao.get(SituacaoChoices.RECONVOCACAO, 0),
+        "nao-escolha": por_situacao.get(SituacaoChoices.NAO_ESCOLHA, 0),
+    }
+
+
+def _montar_dres(concurso_uuid, ano, processo_uuids) -> list:
+    """
+    Une, por DRE, as escolhas realizadas (situacao=escolha, com vaga) e as
+    vagas ofertadas (definitivas + precarias) dos processos informados.
+
+    DRE só com escolha -> vagas=0; DRE só com vaga -> escolhas=0.
+    Nome da DRE = ``Dre.nome``.
+    """
+    # escolhas por DRE: somente situacao=escolha (têm vaga_escola)
+    escolhas_qs = (
+        Escolha.objects.filter(
+            concurso_uuid=concurso_uuid,
+            criado_em__year=ano,
+            situacao=SituacaoChoices.ESCOLHA,
+            vaga_escola__isnull=False,
+        )
+        .values(
+            dre_uuid=F("vaga_escola__escola__dre__uuid"),
+            nome=F("vaga_escola__escola__dre__nome"),
+        )
+        .annotate(escolhas=Count("uuid"))
+    )
+
+    # vagas por DRE: VagasEscolas filtradas pelos processos do filtro
+    vagas_qs = (
+        VagasEscolas.objects.filter(lote__processo_uuid__in=processo_uuids)
+        .values(
+            dre_uuid=F("escola__dre__uuid"),
+            nome=F("escola__dre__nome"),
+        )
+        .annotate(vagas=Sum(F("vagas_definitivas") + F("vagas_precarias")))
+    )
+
+    # união por DRE (chave = uuid da DRE)
+    dres: dict = {}
+    for item in escolhas_qs:
+        dres[item["dre_uuid"]] = {
+            "nome": item["nome"],
+            "escolhas": item["escolhas"],
+            "vagas": 0,
+        }
+    for item in vagas_qs:
+        entrada = dres.setdefault(
+            item["dre_uuid"],
+            {"nome": item["nome"], "escolhas": 0, "vagas": 0},
+        )
+        entrada["vagas"] = item["vagas"] or 0
+
+    return list(dres.values())

--- a/escolhas/services/extracao_dados.py
+++ b/escolhas/services/extracao_dados.py
@@ -1,12 +1,18 @@
 """Agregações para a extração de dados de escolhas."""
 
+from typing import Any, Optional, Union
+from uuid import UUID
+
 from django.db.models import Count, F, Sum
 
 from escolhas.choices import SituacaoChoices
 from escolhas.models import Escolha, VagasEscolas
 
 
-def montar_extracao_dados(concurso_uuid=None, filtros=None) -> dict:
+def montar_extracao_dados(
+    concurso_uuid: Optional[Union[UUID, str]] = None,
+    filtros: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
     """
     Monta o dicionário de indicadores de escolhas.
 
@@ -23,28 +29,33 @@ def montar_extracao_dados(concurso_uuid=None, filtros=None) -> dict:
     têm ``vaga_escola`` vinculada — filtrar pela vaga as excluiria.
     """
     if filtros:
-        resultado = {}
+        resultado: dict[str, Any] = {}
         for filtro in filtros:
             ano = filtro["ano"]
             processo_uuids = filtro.get("processo_uuids") or []
-            dados = _contar_situacoes(concurso_uuid, ano)
+            dados = contar_escolhas(concurso_uuid, ano)
             dados["dres"] = _montar_dres(concurso_uuid, ano, processo_uuids)
             resultado[str(ano)] = dados
         return resultado
 
-    dados = _contar_situacoes(concurso_uuid, ano=None)
-    dados["dres"] = _montar_dres(concurso_uuid, ano=None, processo_uuids=None)
+    dados = contar_escolhas(concurso_uuid, ano=None)
+    dados["dres"] = _montar_dres(concurso_uuid)
     return {"total": dados}
 
 
-def _contar_situacoes(concurso_uuid, ano) -> dict:
+def contar_escolhas(
+    concurso_uuid: Optional[Union[UUID, str]] = None,
+    ano: Optional[int] = None,
+) -> dict[str, int]:
     qs = Escolha.objects.all()
     if concurso_uuid:
         qs = qs.filter(concurso_uuid=concurso_uuid)
     if ano:
         qs = qs.filter(criado_em__year=ano)
     contagens = qs.values("situacao").annotate(total=Count("uuid"))
-    por_situacao = {item["situacao"]: item["total"] for item in contagens}
+    por_situacao: dict[str, int] = {
+        item["situacao"]: item["total"] for item in contagens
+    }
     return {
         "escolha": por_situacao.get(SituacaoChoices.ESCOLHA, 0),
         "reconvocacao": por_situacao.get(SituacaoChoices.RECONVOCACAO, 0),
@@ -52,7 +63,11 @@ def _contar_situacoes(concurso_uuid, ano) -> dict:
     }
 
 
-def _montar_dres(concurso_uuid, ano, processo_uuids) -> list:
+def _montar_dres(
+    concurso_uuid: Optional[Union[UUID, str]] = None,
+    ano: Optional[int] = None,
+    processo_uuids: Optional[list[Union[UUID, str]]] = None,
+) -> list[dict[str, Any]]:
     """
     Une, por DRE, as escolhas realizadas (situacao=escolha, com vaga) e as
     vagas ofertadas (definitivas + precarias).
@@ -88,7 +103,7 @@ def _montar_dres(concurso_uuid, ano, processo_uuids) -> list:
     ).annotate(vagas=Sum(F("vagas_definitivas") + F("vagas_precarias")))
 
     # união por DRE (chave = uuid da DRE)
-    dres: dict = {}
+    dres: dict[Any, dict[str, Any]] = {}
     for item in escolhas_qs:
         dres[item["dre_uuid"]] = {
             "nome": item["nome"],

--- a/escolhas/services/extracao_dados.py
+++ b/escolhas/services/extracao_dados.py
@@ -6,37 +6,44 @@ from escolhas.choices import SituacaoChoices
 from escolhas.models import Escolha, VagasEscolas
 
 
-def montar_extracao_dados(concurso_uuid, filtros) -> dict:
+def montar_extracao_dados(concurso_uuid=None, filtros=None) -> dict:
     """
-    Monta o dicionário de indicadores de escolhas por ano.
+    Monta o dicionário de indicadores de escolhas.
 
-    Para cada ``ano`` (de ``filtros``), conta as escolhas do ``concurso_uuid``
-    por ``situacao`` (escolha / reconvocacao / nao-escolha), filtrando pelo
-    ano de criação (``criado_em``), e monta o array ``dres`` com escolhas e
-    vagas por DRE.
+    - Com ``filtros``: para cada ``ano`` (de ``filtros``), conta as escolhas do
+      ``concurso_uuid`` por ``situacao`` (escolha / reconvocacao / nao-escolha),
+      filtrando pelo ano de criação (``criado_em``), e monta o array ``dres``
+      com escolhas e vagas por DRE (vagas dos ``processo_uuids`` do ano).
+    - Sem ``filtros`` (None ou lista vazia): retorna uma única chave ``total``
+      agregando as escolhas (de ``concurso_uuid`` se informado, senão de todos
+      os concursos) e, em ``dres``, todas as ``VagasEscolas`` por DRE.
 
     Filtramos por ``Escolha.concurso_uuid`` (sempre preenchido) e NÃO pela
     vaga, porque escolhas ``nao-escolha`` / ``reconvocacao`` normalmente não
     têm ``vaga_escola`` vinculada — filtrar pela vaga as excluiria.
     """
-    resultado = {}
-    for filtro in filtros:
-        ano = filtro["ano"]
-        processo_uuids = filtro.get("processo_uuids") or []
-        dados = _contar_situacoes(concurso_uuid, ano)
-        dados["dres"] = _montar_dres(concurso_uuid, ano, processo_uuids)
-        resultado[str(ano)] = dados
-    return resultado
+    if filtros:
+        resultado = {}
+        for filtro in filtros:
+            ano = filtro["ano"]
+            processo_uuids = filtro.get("processo_uuids") or []
+            dados = _contar_situacoes(concurso_uuid, ano)
+            dados["dres"] = _montar_dres(concurso_uuid, ano, processo_uuids)
+            resultado[str(ano)] = dados
+        return resultado
+
+    dados = _contar_situacoes(concurso_uuid, ano=None)
+    dados["dres"] = _montar_dres(concurso_uuid, ano=None, processo_uuids=None)
+    return {"total": dados}
 
 
 def _contar_situacoes(concurso_uuid, ano) -> dict:
-    contagens = (
-        Escolha.objects.filter(
-            concurso_uuid=concurso_uuid, criado_em__year=ano
-        )
-        .values("situacao")
-        .annotate(total=Count("uuid"))
-    )
+    qs = Escolha.objects.all()
+    if concurso_uuid:
+        qs = qs.filter(concurso_uuid=concurso_uuid)
+    if ano:
+        qs = qs.filter(criado_em__year=ano)
+    contagens = qs.values("situacao").annotate(total=Count("uuid"))
     por_situacao = {item["situacao"]: item["total"] for item in contagens}
     return {
         "escolha": por_situacao.get(SituacaoChoices.ESCOLHA, 0),
@@ -48,35 +55,37 @@ def _contar_situacoes(concurso_uuid, ano) -> dict:
 def _montar_dres(concurso_uuid, ano, processo_uuids) -> list:
     """
     Une, por DRE, as escolhas realizadas (situacao=escolha, com vaga) e as
-    vagas ofertadas (definitivas + precarias) dos processos informados.
+    vagas ofertadas (definitivas + precarias).
+
+    - ``concurso_uuid`` / ``ano`` filtram as escolhas quando informados.
+    - ``processo_uuids`` filtra as vagas quando informado; sem ele (modo
+      agregado), soma todas as ``VagasEscolas``.
 
     DRE só com escolha -> vagas=0; DRE só com vaga -> escolhas=0.
     Nome da DRE = ``Dre.nome``.
     """
     # escolhas por DRE: somente situacao=escolha (têm vaga_escola)
-    escolhas_qs = (
-        Escolha.objects.filter(
-            concurso_uuid=concurso_uuid,
-            criado_em__year=ano,
-            situacao=SituacaoChoices.ESCOLHA,
-            vaga_escola__isnull=False,
-        )
-        .values(
-            dre_uuid=F("vaga_escola__escola__dre__uuid"),
-            nome=F("vaga_escola__escola__dre__nome"),
-        )
-        .annotate(escolhas=Count("uuid"))
+    escolhas_qs = Escolha.objects.filter(
+        situacao=SituacaoChoices.ESCOLHA,
+        vaga_escola__isnull=False,
     )
+    if concurso_uuid:
+        escolhas_qs = escolhas_qs.filter(concurso_uuid=concurso_uuid)
+    if ano:
+        escolhas_qs = escolhas_qs.filter(criado_em__year=ano)
+    escolhas_qs = escolhas_qs.values(
+        dre_uuid=F("vaga_escola__escola__dre__uuid"),
+        nome=F("vaga_escola__escola__dre__nome"),
+    ).annotate(escolhas=Count("uuid"))
 
-    # vagas por DRE: VagasEscolas filtradas pelos processos do filtro
-    vagas_qs = (
-        VagasEscolas.objects.filter(lote__processo_uuid__in=processo_uuids)
-        .values(
-            dre_uuid=F("escola__dre__uuid"),
-            nome=F("escola__dre__nome"),
-        )
-        .annotate(vagas=Sum(F("vagas_definitivas") + F("vagas_precarias")))
-    )
+    # vagas por DRE: filtradas pelos processos do filtro; sem filtro, todas
+    vagas_qs = VagasEscolas.objects.all()
+    if processo_uuids:
+        vagas_qs = vagas_qs.filter(lote__processo_uuid__in=processo_uuids)
+    vagas_qs = vagas_qs.values(
+        dre_uuid=F("escola__dre__uuid"),
+        nome=F("escola__dre__nome"),
+    ).annotate(vagas=Sum(F("vagas_definitivas") + F("vagas_precarias")))
 
     # união por DRE (chave = uuid da DRE)
     dres: dict = {}

--- a/escolhas/tests/views/test_extracao_dados.py
+++ b/escolhas/tests/views/test_extracao_dados.py
@@ -1,0 +1,175 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from escolhas.choices import SituacaoChoices
+from escolhas.models import (
+    Dre,
+    Escola,
+    Escolha,
+    VagasEscolas,
+    VagasEscolasLote,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+def _set_ano(escolha, ano):
+    """criado_em é auto_now_add; sobrescreve via update() para o ano dado."""
+    Escolha.objects.filter(pk=escolha.pk).update(
+        criado_em=datetime(ano, 6, 1, tzinfo=timezone.utc)
+    )
+
+
+def criar_escolha(concurso_uuid, situacao, ano, vaga_escola=None):
+    escolha = Escolha.objects.create(
+        candidato_uuid=uuid.uuid4(),
+        concurso_uuid=concurso_uuid,
+        situacao=situacao,
+        e_retardatario=False,
+        vaga_escola=vaga_escola,
+    )
+    _set_ano(escolha, ano)
+    return escolha
+
+
+def criar_dre(nome):
+    return Dre.objects.create(
+        codigo=uuid.uuid4().hex[:6], nome=nome, sigla=f"SIG-{nome}"
+    )
+
+
+def criar_escola(dre):
+    return Escola.objects.create(
+        codigo_eol=uuid.uuid4().hex[:6],
+        nome_oficial="Escola",
+        dre=dre,
+        cep="00000-000",
+    )
+
+
+def criar_vaga(processo_uuid, dre, definitivas, precarias):
+    lote = VagasEscolasLote.objects.create(
+        processo_uuid=processo_uuid, processo_nome="Processo"
+    )
+    return VagasEscolas.objects.create(
+        escola=criar_escola(dre),
+        lote=lote,
+        data_fechamento_modulo="2025-01-01",
+        cargo_codigo=100,
+        cargo_descricao="Cargo",
+        vagas_definitivas=definitivas,
+        vagas_precarias=precarias,
+        status="1",
+    )
+
+
+def test_extracao_dados_conta_situacoes_por_ano(api_client):
+    url = reverse("extracao-dados-list")
+    concurso_uuid = uuid.uuid4()
+
+    # 2026: 2 escolha, 1 reconvocacao, 1 nao-escolha (todas SEM vaga_escola)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026)
+    criar_escolha(concurso_uuid, SituacaoChoices.RECONVOCACAO, 2026)
+    criar_escolha(concurso_uuid, SituacaoChoices.NAO_ESCOLHA, 2026)
+
+    # 2025: 1 escolha (mesmo concurso, outro ano)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2025)
+
+    # outro concurso nao deve contar
+    criar_escolha(uuid.uuid4(), SituacaoChoices.ESCOLHA, 2026)
+
+    payload = {
+        "concurso_uuid": str(concurso_uuid),
+        "filtros": [{"ano": 2026}, {"ano": 2025}],
+    }
+
+    resp = api_client.post(url, payload, format="json")
+
+    assert resp.status_code == 200, resp.content
+    data = resp.json()
+
+    # sem processo_uuids e sem escolhas com vaga -> dres vazio
+    assert data["2026"] == {
+        "escolha": 2,
+        "reconvocacao": 1,
+        "nao-escolha": 1,
+        "dres": [],
+    }
+    assert data["2025"] == {
+        "escolha": 1,
+        "reconvocacao": 0,
+        "nao-escolha": 0,
+        "dres": [],
+    }
+
+
+def test_extracao_dados_dres_uniao_escolhas_e_vagas(api_client):
+    url = reverse("extracao-dados-list")
+    concurso_uuid = uuid.uuid4()
+    processo = uuid.uuid4()
+
+    dre_a = criar_dre("DRE-A")  # tem escolha E vaga
+    dre_b = criar_dre("DRE-B")  # so vaga (sem escolha)
+    dre_c = criar_dre("DRE-C")  # so escolha (sem vaga no processo)
+
+    # vagas no processo filtrado
+    vaga_a = criar_vaga(processo, dre_a, definitivas=70, precarias=50)  # 120
+    criar_vaga(processo, dre_b, definitivas=60, precarias=40)  # 100
+
+    # vaga da DRE-C em OUTRO processo (nao deve contar nas vagas)
+    vaga_c_outro = criar_vaga(uuid.uuid4(), dre_c, definitivas=10, precarias=5)
+
+    # escolhas (situacao=escolha) com vaga -> entram em escolhas por DRE
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026, vaga_a)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026, vaga_a)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026, vaga_c_outro)
+
+    # nao-escolha / reconvocacao sem vaga -> NAO entram em dres
+    criar_escolha(concurso_uuid, SituacaoChoices.NAO_ESCOLHA, 2026)
+    criar_escolha(concurso_uuid, SituacaoChoices.RECONVOCACAO, 2026)
+
+    payload = {
+        "concurso_uuid": str(concurso_uuid),
+        "filtros": [{"ano": 2026, "processo_uuids": [str(processo)]}],
+    }
+
+    resp = api_client.post(url, payload, format="json")
+
+    assert resp.status_code == 200, resp.content
+    ano = resp.json()["2026"]
+
+    assert ano["escolha"] == 3
+    assert ano["reconvocacao"] == 1
+    assert ano["nao-escolha"] == 1
+
+    dres = {d["nome"]: d for d in ano["dres"]}
+    assert dres["DRE-A"] == {"nome": "DRE-A", "escolhas": 2, "vagas": 120}
+    # DRE-B: so vaga
+    assert dres["DRE-B"] == {"nome": "DRE-B", "escolhas": 0, "vagas": 100}
+    # DRE-C: so escolha (vaga em outro processo -> vagas 0)
+    assert dres["DRE-C"] == {"nome": "DRE-C", "escolhas": 1, "vagas": 0}
+    assert set(dres.keys()) == {"DRE-A", "DRE-B", "DRE-C"}
+
+
+def test_extracao_dados_exige_concurso_uuid(api_client):
+    url = reverse("extracao-dados-list")
+    resp = api_client.post(url, {"filtros": [{"ano": 2026}]}, format="json")
+    assert resp.status_code == 400
+
+
+def test_extracao_dados_exige_filtros(api_client):
+    url = reverse("extracao-dados-list")
+    resp = api_client.post(
+        url, {"concurso_uuid": str(uuid.uuid4())}, format="json"
+    )
+    assert resp.status_code == 400

--- a/escolhas/tests/views/test_extracao_dados.py
+++ b/escolhas/tests/views/test_extracao_dados.py
@@ -161,15 +161,56 @@ def test_extracao_dados_dres_uniao_escolhas_e_vagas(api_client):
     assert set(dres.keys()) == {"DRE-A", "DRE-B", "DRE-C"}
 
 
-def test_extracao_dados_exige_concurso_uuid(api_client):
+def test_extracao_dados_sem_filtros_retorna_total(api_client):
     url = reverse("extracao-dados-list")
-    resp = api_client.post(url, {"filtros": [{"ano": 2026}]}, format="json")
-    assert resp.status_code == 400
+    concurso_uuid = uuid.uuid4()
+    processo = uuid.uuid4()
+
+    dre_a = criar_dre("DRE-A")  # tem escolha E vaga
+    dre_b = criar_dre("DRE-B")  # so vaga (sem escolha)
+
+    vaga_a = criar_vaga(processo, dre_a, definitivas=70, precarias=50)  # 120
+    criar_vaga(uuid.uuid4(), dre_b, definitivas=60, precarias=40)  # 100
+
+    # escolhas do concurso em anos diferentes -> agregadas no total
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2026, vaga_a)
+    criar_escolha(concurso_uuid, SituacaoChoices.ESCOLHA, 2025, vaga_a)
+    criar_escolha(concurso_uuid, SituacaoChoices.RECONVOCACAO, 2026)
+    criar_escolha(concurso_uuid, SituacaoChoices.NAO_ESCOLHA, 2026)
+
+    payload = {"concurso_uuid": str(concurso_uuid)}
+
+    resp = api_client.post(url, payload, format="json")
+
+    assert resp.status_code == 200, resp.content
+    data = resp.json()
+
+    # sem quebra por ano: apenas a chave "total"
+    assert set(data.keys()) == {"total"}
+    total = data["total"]
+    assert total["escolha"] == 2
+    assert total["reconvocacao"] == 1
+    assert total["nao-escolha"] == 1
+
+    dres = {d["nome"]: d for d in total["dres"]}
+    # DRE-A: 2 escolhas (anos diferentes agregados) + todas as vagas
+    assert dres["DRE-A"] == {"nome": "DRE-A", "escolhas": 2, "vagas": 120}
+    # DRE-B: so vaga (todas as VagasEscolas entram no agregado)
+    assert dres["DRE-B"] == {"nome": "DRE-B", "escolhas": 0, "vagas": 100}
+    assert set(dres.keys()) == {"DRE-A", "DRE-B"}
 
 
-def test_extracao_dados_exige_filtros(api_client):
+def test_extracao_dados_body_vazio_agrega_tudo(api_client):
     url = reverse("extracao-dados-list")
-    resp = api_client.post(
-        url, {"concurso_uuid": str(uuid.uuid4())}, format="json"
-    )
-    assert resp.status_code == 400
+
+    # escolhas de concursos diferentes -> todas contam no agregado
+    criar_escolha(uuid.uuid4(), SituacaoChoices.ESCOLHA, 2026)
+    criar_escolha(uuid.uuid4(), SituacaoChoices.NAO_ESCOLHA, 2025)
+
+    resp = api_client.post(url, {}, format="json")
+
+    assert resp.status_code == 200, resp.content
+    data = resp.json()
+    assert set(data.keys()) == {"total"}
+    assert data["total"]["escolha"] == 1
+    assert data["total"]["nao-escolha"] == 1

--- a/escolhas/urls.py
+++ b/escolhas/urls.py
@@ -9,6 +9,7 @@ from .views import (
     DreViewSet,
     EscolaViewSet,
     EscolhaViewSet,
+    ExtracaoDadosViewSet,
     ParametrizacaoViewSet,
     VagasEscolasViewSet,
 )
@@ -17,6 +18,9 @@ router = DefaultRouter()
 router.register(r"escolhas", EscolhaViewSet, basename="escolha")
 router.register(r"escolas", EscolaViewSet, basename="escola")
 router.register(r"dres", DreViewSet, basename="dre")
+router.register(
+    r"extracao-dados", ExtracaoDadosViewSet, basename="extracao-dados"
+)
 router.register(
     r"vagas-escolas", VagasEscolasViewSet, basename="vagas-escolas"
 )

--- a/escolhas/views/__init__.py
+++ b/escolhas/views/__init__.py
@@ -1,6 +1,7 @@
 from .dre import DreViewSet
 from .escola import EscolaViewSet
 from .escolha import EscolhaViewSet
+from .extracao_dados import ExtracaoDadosViewSet
 from .parametrizacao import ParametrizacaoViewSet
 from .vagas_escolas import VagasEscolasViewSet
 
@@ -8,6 +9,7 @@ __all__ = [
     "EscolhaViewSet",
     "EscolaViewSet",
     "DreViewSet",
+    "ExtracaoDadosViewSet",
     "VagasEscolasViewSet",
     "ParametrizacaoViewSet",
 ]

--- a/escolhas/views/extracao_dados.py
+++ b/escolhas/views/extracao_dados.py
@@ -1,0 +1,29 @@
+"""ViewSet de extração de dados de escolhas."""
+
+from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from ..serializers import ExtracaoDadosSerializer
+from ..services import montar_extracao_dados
+
+
+class ExtracaoDadosViewSet(viewsets.ViewSet):
+    """
+    Indicadores de escolhas para extração de dados.
+
+    POST /extracao-dados/
+    Body: {concurso_uuid, filtros: [{ano}]}
+    """
+
+    permission_classes = [AllowAny]
+
+    def create(self, request):
+        serializer = ExtracaoDadosSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        dados = serializer.validated_data
+        resultado = montar_extracao_dados(
+            concurso_uuid=dados["concurso_uuid"],
+            filtros=dados["filtros"],
+        )
+        return Response(resultado)

--- a/escolhas/views/extracao_dados.py
+++ b/escolhas/views/extracao_dados.py
@@ -13,7 +13,8 @@ class ExtracaoDadosViewSet(viewsets.ViewSet):
     Indicadores de escolhas para extração de dados.
 
     POST /extracao-dados/
-    Body: {concurso_uuid, filtros: [{ano}]}
+    Body: {concurso_uuid?, filtros?: [{ano, processo_uuids?}]}
+    Sem `filtros`: retorna a chave "total" agregando todas as escolhas.
     """
 
     permission_classes = [AllowAny]
@@ -23,7 +24,7 @@ class ExtracaoDadosViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
         dados = serializer.validated_data
         resultado = montar_extracao_dados(
-            concurso_uuid=dados["concurso_uuid"],
+            concurso_uuid=dados.get("concurso_uuid"),
             filtros=dados["filtros"],
         )
         return Response(resultado)


### PR DESCRIPTION
## Descrição

Adiciona o endpoint `POST /api/v1/extracao-dados/` no MS-Escolha, que fornece os
indicadores consolidados de **escolhas** por concurso e ano — totais por situação
(escolha / reconvocação / não-escolha) e o detalhamento por DRE (escolhas e vagas)
— para a tela de Indicadores (extração de dados).

## O que foi feito

- Novo `ExtracaoDadosViewSet` (`viewsets.ViewSet`, `AllowAny`) registrado no router
  como `extracao-dados`.
- Novo serializer de entrada `ExtracaoDadosSerializer` (valida `concurso_uuid` e a
  lista `filtros` de `{ano, processo_uuids?}`).
- Nova camada de serviço `services/extracao_dados.py` com a lógica de agregação
  (`montar_extracao_dados`), exportada no `services/__init__.py`.

## Endpoint

`POST /api/v1/extracao-dados/`

**Request:**
```json
{
  "concurso_uuid": "161a2dc7-d349-4dd3-9473-4bd51685347b",
  "filtros": [
    { "ano": 2026, "processo_uuids": ["a1b2c3d4-...", "f6e5d4c3-..."] },
    { "ano": 2025, "processo_uuids": ["98765432-..."] }
  ]
}
```

[AB#150057](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/150057)
[AB#148916](https://dev.azure.com/SME-Spassu/bd1a795a-42dd-4c65-8d4e-99a11b87f228/_workitems/edit/148916)
